### PR TITLE
Resolved #267

### DIFF
--- a/Publish/Portal/PortalContentPost.py
+++ b/Publish/Portal/PortalContentPost.py
@@ -451,6 +451,10 @@ def create_user(portaladmin,contentpath,userinfo):
         role = userproperties["role"]
         email = userproperties["email"]
         
+        # Check for null email
+        if not email:
+            email = username + '@no_email_in_user_profile.org'
+
         # Create user
         portaladmin.signup(username,password,fullname,email)
         


### PR DESCRIPTION
- Modified so default email is provided when creating users that don't
  have an email address.
