### PR TITLE
Fix to #1428

### DIFF
--- a/Publish/Portal/PortalContentPost.py
+++ b/Publish/Portal/PortalContentPost.py
@@ -635,10 +635,15 @@ def publish_user_groups(portal,contentpath, userinfo, users):
         
         # Create group if it doesn't exist
         if not groupId:
-            print "... group '" + str(group['title']) + "'"
+            print "... group '" + str(group['title']) + "' (" + str(group['id']) + ")"
             groupId = portal.create_group(group,group['thumbfile'])
+            
             # Reassign group
-            portal.reassign_group(groupId, username)
+            if groupId:
+                print "... reassigning group to user '" + str(username) + "'"
+                portal.reassign_group(groupId, username)
+            else:
+                print "ERROR: Can't create group '" + str(group['title']) + "'"
         else:
             print "... group '" + str(group['title']) + "' already exists."
             

--- a/Publish/Portal/portalpy/__init__.py
+++ b/Publish/Portal/portalpy/__init__.py
@@ -1226,7 +1226,11 @@ class Portal(object):
 
         postdata = self._postdata()
         postdata.update(unicode_to_ascii(group))
-
+        
+        # createGroup accepts form-data, so convert lists to strings
+        postdata['capabilities'] = ','.join(postdata['capabilities'])
+        postdata['tags'] = ','.join(postdata['tags'])
+        
         # Build the files list (tuples)
         files = []
         if thumbnail:


### PR DESCRIPTION
PortalContentPost.py failing with "Invalid group capability" error.

The issue is that the createGroup endpoint in the portal sharing api
only accepts form-data and not json. So the capabilities and tags list
properties had to be converted to comma delimited strings.

Also modified the PortalContentPost.py script to print out the original
group id so that debugging issues would be easier. Added an addition
if/else block around the call to the reassign_group function to only
call if the group was created.