### PR TITLE
Mods to Extract and Post scripts related to "esri_" accounts

### DIFF
--- a/Publish/Portal/PortalContentExtract.py
+++ b/Publish/Portal/PortalContentExtract.py
@@ -139,9 +139,16 @@ def extract_portal(portaladdress,contentpath,adminuser,adminpassword, specifiedU
     # ------------------------------------------------------------------------       
     print "\n- Extracting users, groups and items ..."
     
-    # Get list of users on the source portal
     usersList = []
-    usersListAllNames = portaladmin.users()
+    usersListAllNames = []
+    
+    # Get list of users on the source portal
+    usersListAllNames_temp = portaladmin.users()
+    
+    # Remove any esri_ accounts from the list
+    for u in usersListAllNames_temp:
+        if not u["username"].startswith("esri_"):
+            usersListAllNames.append(u)
     
     # Create list of users that we don't want to extract content for.
     # NOTE: specify user names in lowercase.

--- a/Publish/Portal/PortalContentPost.py
+++ b/Publish/Portal/PortalContentPost.py
@@ -309,8 +309,17 @@ def publish_portal(portaladdress,contentpath,adminuser,adminpassword, users, hos
     
     # Add the group ids to the dictionary of old/new ids
     origIDToNewID.update(oldGrpID_newGrpID)
+
+    # Create list of items to update
+    # (exclude any items owned by esri_ accounts)
+    items_all = portaladmin.search()
+    items_to_update = []
+    for item in items_all:
+        if not item["owner"].startswith("esri_"):
+            items_to_update.append(item)
     
-    update_post_publish(portaladmin, hostname_map, origIDToNewID)
+    # Update
+    update_post_publish(portaladmin, hostname_map, origIDToNewID, items_to_update)
 
     # Comment out: this functionality is now available out of the box
     # # ------------------------------------------------------------------------
@@ -737,12 +746,9 @@ def publish_get_folder_name_for_item(item, folders):
             
     return folderName
 
-def update_post_publish(portal, hostname_map, id_map):
+def update_post_publish(portal, hostname_map, id_map, items):
     '''Replace server name and update item IDs referenced in items'''
 
-    # Return all portal items
-    items = portal.search()
-    
     for item in items:
         
         print_item_info(item)


### PR DESCRIPTION
Fix to issue #1453 - Modify PortalContentExtract.py script to not extract "esri" owned items

Fix to issue #1452 - Modify PortalContentPost.py script so it doesn't update ids/urls in "esri" owned items
