### PR TITLE
Fix to #1482

### DIFF
--- a/Publish/Portal/portalpy/__init__.py
+++ b/Publish/Portal/portalpy/__init__.py
@@ -1235,7 +1235,8 @@ class Portal(object):
         postdata.update(unicode_to_ascii(group))
         
         # createGroup accepts form-data, so convert lists to strings
-        postdata['capabilities'] = ','.join(postdata['capabilities'])
+        if 'capabilities' in postdata:
+            postdata['capabilities'] = ','.join(postdata['capabilities'])
         postdata['tags'] = ','.join(postdata['tags'])
         
         # Build the files list (tuples)


### PR DESCRIPTION
create_group function in Portalpy module fails when 'capabilities' key
does not exist